### PR TITLE
CI: lts-dev → lts, sonar workflow → @main; обновлена зависимость autumn-collections до 0.1.1

### DIFF
--- a/.github/workflows/perfomance.yml
+++ b/.github/workflows/perfomance.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        oscript_version: ['dev', 'lts-dev', 'default']
+        oscript_version: ['dev', 'lts', 'default']
     uses: autumn-library/workflows/.github/workflows/test.yml@main
     with:
       oscript_version: ${{ matrix.oscript_version }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sonar:
-    uses: autumn-library/workflows/.github/workflows/sonar.yml@coverage
+    uses: autumn-library/workflows/.github/workflows/sonar.yml@main
     with:
       github_repository: autumn-library/autumn
       coveralls: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        oscript_version: ['dev', 'lts-dev', 'default']
+        oscript_version: ['dev', 'lts', 'default']
     uses: autumn-library/workflows/.github/workflows/test.yml@main
     with:
       oscript_version: ${{ matrix.oscript_version }}

--- a/packagedef
+++ b/packagedef
@@ -22,7 +22,7 @@
         .ЗависитОт("reflector", "0.7.1")
         .ЗависитОт("semaphore", "1.1.0")
         .ЗависитОт("collectionos", "0.7.2")
-        .ЗависитОт("autumn-collections", "0.1.0")
+        .ЗависитОт("autumn-collections", "0.1.1")
         .ЗависитОт("lambdas", "0.3.2")
 
         .РазработкаЗависитОт("1testrunner")


### PR DESCRIPTION
## Что сделано

- **`.github/workflows/testing.yml`** и **`.github/workflows/perfomance.yml`** — заменил `lts-dev` на `lts` в матрице `oscript_version`. Алиас `latest-dev` больше не публикуется на сайте дистрибутивов OneScript, из-за чего все matrix-задания с `lts-dev` падали на установке (ovm: `Не удалось найти версию latest-dev на сайте`).
- **`.github/workflows/qa.yml`** — переключил `autumn-library/workflows/.github/workflows/sonar.yml` с ветки `@coverage` на `@main`. На `@coverage` SonarScanner/BSL Plugin собран под Java 21 (class file 65.0), а раннер тянет Java 17 — все запуски падали.
- **`packagedef`** — `autumn-collections` поднят с `0.1.0` до [`0.1.1`](https://github.com/autumn-library/autumn-collections/releases/tag/v0.1.1) (свежий патч с описанным публичным API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)